### PR TITLE
Correction to index buffer type in loadMeshBVH

### DIFF
--- a/src/runtimerender/resourcemanager/qssgrenderbuffermanager.cpp
+++ b/src/runtimerender/resourcemanager/qssgrenderbuffermanager.cpp
@@ -1778,7 +1778,7 @@ std::unique_ptr<QSSGMeshBVH> QSSGBufferManager::loadMeshBVH(QSSGRenderGeometry *
 
     // Build BVH
     bool hasIndexBuffer = false;
-    QSSGRenderComponentType indexBufferFormat = QSSGRenderComponentType::Int32;
+    QSSGRenderComponentType indexBufferFormat = QSSGRenderComponentType::UnsignedInt32;
     bool hasUV = false;
     int uvOffset = -1;
     int posOffset = -1;
@@ -1795,10 +1795,10 @@ std::unique_ptr<QSSGMeshBVH> QSSGBufferManager::loadMeshBVH(QSSGRenderGeometry *
             uvOffset = attribute.offset;
         } else if (attribute.semantic == QSSGMesh::RuntimeMeshData::Attribute::IndexSemantic) {
             hasIndexBuffer = true;
-            if (attribute.componentType == QSSGMesh::Mesh::ComponentType::Int16)
-                indexBufferFormat = QSSGRenderComponentType::Int16;
-            else if (attribute.componentType == QSSGMesh::Mesh::ComponentType::Int32)
-                indexBufferFormat = QSSGRenderComponentType::Int32;
+            if (attribute.componentType == QSSGMesh::Mesh::ComponentType::UnsignedInt16)
+                indexBufferFormat = QSSGRenderComponentType::UnsignedInt16;
+            else if (attribute.componentType == QSSGMesh::Mesh::ComponentType::UnsignedInt32)
+                indexBufferFormat = QSSGRenderComponentType::UnsignedInt32;
         }
     }
 


### PR DESCRIPTION
Only unsigned integer types are supported for user-supplied meshes in QQuick3DGeometry, and make sense for index buffers in general. The pre-set signed indexBufferFormat was always used in the old code, since "attribute.componentType" (either uint32 or uint16) never matched any of the signed alternatives in the if-clauses. This appears to have worked fine with uint32 buffers, but caused crashes with uint16 (due to out-of-bounds accesses caused by bad casts downstream).